### PR TITLE
fix: rename contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 `witnet-ethereum-block-relay` is an open source implementation of Witnet Block Relay for EVM-compatible blockchains.
 
-
- DISCLAIMER: this is a work in progress, by which we mean the contract could still be vulnerable to attack. Use at your own risk.
+DISCLAIMER: this is a work in progress, by which we mean the contract could still be vulnerable to attack. Use at your own risk.
 
 ## About WBI and the Block Relay
 
@@ -24,7 +23,7 @@ The following diagram shows the flow between the WBI and the Block Relay.
 
 ## BlockRelay based on ABS
 
-The `ABSBlockRelay` is a work in progress contract that implements the Active Bridge Set (ABS) as the set in charge of proposing and posting blocks to the Block Relay. The ABS is a subset of bridge nodes and is updated in the contract when posting a block through the WBI.
+The `ActiveBridgeSetBlockRelay` is a work in progress contract that implements the Active Bridge Set (ABS) as the set in charge of proposing and posting blocks to the Block Relay. The ABS is a subset of bridge nodes and is updated in the contract when posting a block through the WBI.
 
 A block header is later finalized when 2/3 of the ABS agree on a vote. More precisely, the flow is as follows:
 
@@ -119,9 +118,9 @@ The `CentralizedBlockRelay` contract contains the following methods:
     - *_index* the index in the merkle tree of the element to verify
     - *_element* the leaf to be verified
 
-### ABSBlockRelay
+### ActiveBridgeSetBlockRelay
 
-The `ABSBlockRelay` contract is similar to the `CentralizedBlockRelay` but instead of being centralized, the members of the ABS are in charge of proposing blocks.
+The `ActiveBridgeSetBlockRelay` contract is similar to the `CentralizedBlockRelay` but instead of being centralized, the members of the ABS are in charge of proposing blocks.
 The following functions differ from the `CentralizedBlockRelay`:
 
 - **proposeBlock**:
@@ -146,7 +145,7 @@ The following functions differ from the `CentralizedBlockRelay`:
 ## Known limitations:
 
 - `CentralizedBlockRelay`: as the name suggests, this block relay is centralized, only the deployer of the contract is able to push blocks.
-- `ABSBlockRelay`: the ABS stays the same until a block is finalized. A block can be proposed more than once by the same ABS member and only for one epoch previous to the current epoch.
+- `ActiveBridgeSetBlockRelay`: the ABS stays the same until a block is finalized. A block can be proposed more than once by the same ABS member and only for one epoch previous to the current epoch.
 
 ## Future steps
 

--- a/contracts/ABSWitnetRequestsBoardInterface.sol
+++ b/contracts/ABSWitnetRequestsBoardInterface.sol
@@ -1,13 +1,13 @@
 pragma solidity ^0.5.0;
 /**
- * @title ABS Interface
- * @notice Interface of a WBI with ABS methods
+ * @title Active Bridge Set Witnet Requests Board
+ * @notice Interface of a Witnet Requests Board with ABS methods
  * It defines how to interact with the Block Relay in order to support:
  *  - Check if an address is a ABS member
  *  - Get the number of members of the ABS
  * @author Witnet Foundation
  */
-interface ABSInterface {
+interface ABSWitnetRequestsBoardInterface {
 
   function isABSMember(address _address) external view returns (bool);
 

--- a/contracts/ActiveBridgeSetBlockRelay.sol
+++ b/contracts/ActiveBridgeSetBlockRelay.sol
@@ -1,17 +1,17 @@
 pragma solidity ^0.5.0;
 
-import "./ABSInterface.sol";
+import "./ABSWitnetRequestsBoardInterface.sol";
 import "./BlockRelayInterface.sol";
 
 
 /**
- * @title ABS Block relay contract
+ * @title Active Bridge Set Block relay contract
  * @notice Contract to store/read block headers from the Witnet network, implements BFT Finality bsaed on the Active Bridge Set (ABS)
  * @dev More information can be found here https://github.com/witnet/research/blob/master/bridge/docs/BFT_finality.md
  * DISCLAIMER: this is a work in progress, meaning the contract could be voulnerable to attacks
  * @author Witnet Foundation
  */
-contract ABSBlockRelay is BlockRelayInterface {
+contract ActiveBridgeSetBlockRelay is BlockRelayInterface {
 
   struct MerkleRoots {
     // Hash of the merkle root of the DRs in Witnet
@@ -69,7 +69,7 @@ contract ABSBlockRelay is BlockRelayInterface {
   // Witnet address
   address witnet;
 
-  ABSInterface wbi;
+  ABSWitnetRequestsBoardInterface wbi;
 
   // Last block reported
   Beacon public lastBlock;
@@ -132,7 +132,7 @@ contract ABSBlockRelay is BlockRelayInterface {
     witnetGenesis = _witnetGenesis;
     epochSeconds = _epochSeconds;
     firstBlock = _firstBlock;
-    wbi = ABSInterface(_wbiAddress);
+    wbi = ABSWitnetRequestsBoardInterface(_wbiAddress);
     witnet = msg.sender;
   }
 

--- a/contracts/mocks/ActiveBridgeSetMock.sol
+++ b/contracts/mocks/ActiveBridgeSetMock.sol
@@ -1,14 +1,14 @@
 pragma solidity ^0.5.0;
 
-import "../ABSInterface.sol";
+import "../ABSWitnetRequestsBoardInterface.sol";
 
 
 /**
- * @title Mock of the wbi to get the ABS interface methods
+ * @title Mock of the Witnet Requests Board to get the ABSWitnetRequestsBoardInterface methods
  * @dev The aim of this contract is to mock the ABS methods for testing purposes
  * @author Witnet Foundation
  */
-contract ABSMock is ABSInterface {
+contract ActiveBridgeSetMock is ABSWitnetRequestsBoardInterface {
 
   mapping(address => bool) fakeABS;
 

--- a/test/abs_block_relay.js
+++ b/test/abs_block_relay.js
@@ -1,6 +1,6 @@
 const sha = require("js-sha256")
-const ABSBRTestHelper = artifacts.require("ABSBRTestHelper")
-const ABSMock = artifacts.require("ABSMock")
+const ABSBlockRelayTestHelper = artifacts.require("ABSBlockRelayTestHelper")
+const ABSMock = artifacts.require("ActiveBridgeSetMock")
 const truffleAssert = require("truffle-assertions")
 contract("ABS Block Relay", accounts => {
   describe("ABS block relay test suite", () => {
@@ -11,7 +11,7 @@ contract("ABS Block Relay", accounts => {
         from: accounts[0],
       })
 
-      contest = await ABSBRTestHelper.new(1568559600, 90, 0, abs.address, {
+      contest = await ABSBlockRelayTestHelper.new(1568559600, 90, 0, abs.address, {
         from: accounts[0],
       })
     })

--- a/test/helpers/ABSBlockRelayTestHelper.sol
+++ b/test/helpers/ABSBlockRelayTestHelper.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.0;
 
-import "../../contracts/ABSBlockRelay.sol";
+import "../../contracts/ActiveBridgeSetBlockRelay.sol";
 
 
 /**
@@ -8,9 +8,9 @@ import "../../contracts/ABSBlockRelay.sol";
  * @dev The aim of this contract is to raise the visibility modifier of new block relay contract functions for testing purposes
  * @author Witnet Foundation
  */
-contract ABSBRTestHelper is ABSBlockRelay {
+contract ABSBlockRelayTestHelper is ActiveBridgeSetBlockRelay {
 
-  ABSBlockRelay br;
+  ActiveBridgeSetBlockRelay br;
   uint256 timestamp;
   uint256 witnetGenesis;
   uint256 firstBlock;
@@ -18,7 +18,7 @@ contract ABSBRTestHelper is ABSBlockRelay {
 
   constructor (
     uint256 _witnetGenesis, uint256 _epochSeconds, uint256 _firstBlock, address _wbiAddress)
-  ABSBlockRelay(_witnetGenesis, _epochSeconds, _firstBlock, _wbiAddress) public {}
+  ActiveBridgeSetBlockRelay(_witnetGenesis, _epochSeconds, _firstBlock, _wbiAddress) public {}
 
   // Updates the currentEpoch
   function updateEpoch() public view returns (uint256) {


### PR DESCRIPTION
Renamed contracts:

- ABSBlockRelay to ActiveBridgeSetBlockRelay
- ABSMock to ActiveBridgeSetMock
- ABSInterface to ABSWitnetRequestsBoardInterface
- ABSBRTestHelper to ABSBlockRelayTestHelper

This PR is part of https://github.com/witnet/witnet-ethereum-bridge/issues/58