### PR TITLE
feat: add committee to centralized br

### DIFF
--- a/migrations/2_deploy_cent_block_relay.js
+++ b/migrations/2_deploy_cent_block_relay.js
@@ -1,6 +1,6 @@
 var CentralizedBlockRelay = artifacts.require("CentralizedBlockRelay")
 
-module.exports = function (deployer, network) {
+module.exports = function (deployer, network, accounts) {
   console.log(`> Migrating CentralizedBlockRelay into ${network} network`)
-  deployer.deploy(CentralizedBlockRelay)
+  deployer.deploy(CentralizedBlockRelay, [accounts[0]])
 }


### PR DESCRIPTION
The Centralized block relay should have a committee defined when deployed, so that not only onne address can post blocks
